### PR TITLE
Fix production analytics and security header issues

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -60,6 +60,8 @@ const SECURITY_HEADERS = [
       'magnetometer=()',
       'gyroscope=()',
       'accelerometer=()',
+      'browsing-topics=()',
+      'interest-cohort=()',
     ].join(', '),
   },
   {
@@ -277,6 +279,43 @@ const nextConfig = {
       ],
     });
 
+    // Analytics proxy CORS headers
+    headers.push({
+      source: '/script.js',
+      headers: [
+        {
+          key: 'Access-Control-Allow-Origin',
+          value: 'https://jorismathijssen.nl',
+        },
+        {
+          key: 'Access-Control-Allow-Methods',
+          value: 'GET, POST, OPTIONS',
+        },
+        {
+          key: 'Access-Control-Allow-Headers',
+          value: 'Content-Type, Authorization',
+        },
+      ],
+    });
+
+    headers.push({
+      source: '/api/(send|stats)/:path*',
+      headers: [
+        {
+          key: 'Access-Control-Allow-Origin',
+          value: 'https://jorismathijssen.nl',
+        },
+        {
+          key: 'Access-Control-Allow-Methods',
+          value: 'GET, POST, OPTIONS',
+        },
+        {
+          key: 'Access-Control-Allow-Headers',
+          value: 'Content-Type, Authorization',
+        },
+      ],
+    });
+
     return headers;
   },
 
@@ -301,9 +340,18 @@ const nextConfig = {
   async rewrites() {
     return [
       // Umami Analytics - Ad blocker bypass rewrites
-      // Proxy the main tracker script
+      // Proxy the main tracker script (primary)
+      {
+        source: '/script.js',
+        destination: 'https://analytics.jorismathijssen.nl/script.js',
+      },
+      // Proxy alternative script names (ad blocker bypass)
       {
         source: '/stats.js',
+        destination: 'https://analytics.jorismathijssen.nl/script.js',
+      },
+      {
+        source: '/t.js',
         destination: 'https://analytics.jorismathijssen.nl/script.js',
       },
       // Proxy the stats collection endpoint
@@ -311,10 +359,10 @@ const nextConfig = {
         source: '/api/stats/:path*',
         destination: 'https://analytics.jorismathijssen.nl/api/:path*',
       },
-      // Alternative tracker script name (common bypass technique)
+      // Proxy send endpoint (used by Umami)
       {
-        source: '/t.js',
-        destination: 'https://analytics.jorismathijssen.nl/script.js',
+        source: '/api/send',
+        destination: 'https://analytics.jorismathijssen.nl/api/send',
       },
       
       // API rewrites


### PR DESCRIPTION
## Summary
This PR fixes critical production issues affecting analytics tracking and security headers on https://jorismathijssen.nl

## Issues Fixed

### 🔒 Security Headers
- **Fixed Permissions-Policy warning** - Added explicit `browsing-topics=()` and `interest-cohort=()` to disable unsupported features
- **Eliminated browser warnings** about unrecognized Permissions-Policy features

### 📊 Umami Analytics Issues  
- **Fixed script.js 404 error** - Added `/script.js` rewrite to proxy Umami analytics script
- **Fixed CORS errors** - Added proper CORS headers for analytics proxy endpoints
- **Fixed MIME type errors** - Proper handling of analytics script loading with correct MIME types
- **Added missing API endpoint** - Added `/api/send` proxy for analytics data collection

### 🔧 Configuration Improvements
- **Enhanced proxy coverage** - Multiple script path options (`/script.js`, `/stats.js`, `/t.js`) for ad-blocker bypass
- **Proper CORS configuration** - Origin-specific CORS headers for analytics endpoints
- **Better error handling** - Eliminated MIME type checking issues

## Changes Made

### Next.js Configuration (`next.config.mjs`)
- Added `/script.js` → `https://analytics.jorismathijssen.nl/script.js` rewrite
- Added `/api/send` → `https://analytics.jorismathijssen.nl/api/send` rewrite  
- Added CORS headers for `/script.js` and `/api/(send|stats)/:path*`
- Updated Permissions-Policy to explicitly disable `browsing-topics` and `interest-cohort`

## Test Plan
- [x] Build completes successfully
- [x] All tests pass
- [x] Linting passes
- [x] Configuration syntax is valid
- [ ] Production deployment works without console errors
- [ ] Analytics tracking functions properly
- [ ] No security header warnings

## Expected Production Impact
- ✅ No more "Error with Permissions-Policy header" warnings
- ✅ Analytics script loads without 404 errors
- ✅ No more CORS blocking of analytics requests  
- ✅ Proper MIME type handling for analytics scripts

🤖 Generated with [Claude Code](https://claude.ai/code)